### PR TITLE
Add Redis session store.

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -2,5 +2,6 @@ export type { MiddlewareHandlerContext } from "https://deno.land/x/fresh@1.0.1/s
 export {
   getCookies,
   setCookie,
+  deleteCookie
 } from "https://deno.land/std@0.150.0/http/mod.ts";
 export { create, decode, verify } from "https://deno.land/x/djwt@v2.7/mod.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,2 +1,3 @@
 export * from "./stores/cookie.ts";
+export * from "./stores/redis.ts";
 export * from "./session.ts";

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,7 +1,8 @@
 export class Session {
   #data = new Map();
   #flash = new Map();
-
+  #doDelete = false;
+  
   constructor(data = {}, flash = {}) {
     this.#data = new Map(Object.entries(data));
     this.#flash = new Map(Object.entries(flash));
@@ -13,6 +14,10 @@ export class Session {
 
   get flashedData() {
     return Object.fromEntries(this.#flash);
+  }
+
+  get doDelete(){
+    return this.#doDelete
   }
 
   set(key: string, value: any) {
@@ -42,12 +47,12 @@ export class Session {
 
       return flashedValue;
     }
-
     this.#flash.set(key, value);
 
     return this;
   }
 
-  // TODO
-  destroy() {}
+  destroy() {
+    this.#doDelete = true;
+  }
 }

--- a/src/stores/redis.ts
+++ b/src/stores/redis.ts
@@ -1,0 +1,109 @@
+import {
+  deleteCookie,
+  getCookies,
+  MiddlewareHandlerContext,
+  setCookie,
+} from "../deps.ts";
+import { Session } from "../session.ts";
+
+export type WithSession = {
+  session: Session;
+};
+interface Store {
+  set: Function;
+  get: Function;
+  del: Function;
+}
+
+export function createRedisSessionStorage(
+  sessionId: string,
+  store: Store,
+  keyPrefix: string,
+) {
+  return RedisSessionStorage.init(sessionId, store, keyPrefix);
+}
+
+export class RedisSessionStorage {
+  #sessionKey: string;
+  #keyPrefix: string;
+  #store: Store;
+  constructor(key: string, store: Store, keyPrefix: string) {
+    this.#sessionKey = key;
+    this.#store = store;
+    this.#keyPrefix = keyPrefix;
+  }
+
+  static init(sessionKey: string | undefined, store: Store, keyPrefix: string) {
+    let key = !sessionKey ? crypto.randomUUID() : sessionKey;
+
+    return new this(key, store, keyPrefix);
+  }
+
+  get key() {
+    return `${this.#keyPrefix}${this.#sessionKey}`;
+  }
+
+  create() {
+    return new Session();
+  }
+
+  async exists(): Promise<boolean> {
+    return !!(await this.#store.get(this.key));
+  }
+
+  async get() {
+    const { _flash = {}, data } = JSON.parse(await this.#store.get(this.key));
+    return new Session(data as object, _flash);
+  }
+
+  async persist(response: Response, session: Session) {
+    if (session.doDelete) {
+      await this.#store.del(
+        this.key,
+      );
+
+      deleteCookie(response.headers, "sessionId");
+    } else {
+      await this.#store.set(
+        this.key,
+        JSON.stringify({ data: session.data, _flash: session.flashedData }),
+      );
+
+      setCookie(response.headers, {
+        name: "sessionId",
+        value: this.#sessionKey,
+      });
+    }
+
+    return response;
+  }
+}
+
+export function CreateRedisSession(store: Store, keyPrefix = "session_") {
+  const redisStore = store;
+
+  return async function RedisSession(
+    req: Request,
+    ctx: MiddlewareHandlerContext<WithSession>,
+  ) {
+    const { sessionId } = getCookies(req.headers);
+    const redisSessionStorage = await createRedisSessionStorage(
+      sessionId,
+      redisStore,
+      keyPrefix,
+    );
+
+    if (
+      sessionId && (await redisSessionStorage.exists())
+    ) {
+      ctx.state.session = await redisSessionStorage.get();
+    }
+
+    if (!ctx.state.session) {
+      ctx.state.session = redisSessionStorage.create();
+    }
+    const response = await ctx.next();
+
+    return redisSessionStorage.persist(response, ctx.state.session);
+  };
+}


### PR DESCRIPTION
Nice to meet you.

I have added a Redis store as a starting point for a database session.

Here's how to use it.

I also confirmed that it works with upstash for redis, not just Redis.

```typescript _middleware
import { MiddlewareHandlerContext } from "$fresh/server.ts";
import {
  CreateRedisSession,
  WithSession,
} from "fresh-session/mod.ts";
export type State = WithSession;

import { connect } from 'https://deno.land/x/redis@v0.25.0/mod.ts'
const redis = await connect({
  hostname: 'redis',
  port: 6379,
})

// or

import { Redis } from "https://deno.land/x/upstash_redis/mod.ts";
const redis = new Redis({
  url: Deno.env.get("UPSTASH_URL")!,
  token: Deno.env.get("UPSTASH_TOKEN")!,
  automaticDeserialization: false,
});

const redisSession = new CreateRedisSession(redis)

export function handler(
  req: Request,
  ctx: MiddlewareHandlerContext<State>,
) {
  return redisSession(req, ctx);
}
```