### PR TITLE
Setup cookie option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ If you don't know how to setup environment variable locally, I wrote
 
 ```ts
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { createCookieSession, WithSession } from "fresh-session";
+import { cookieSession, WithSession } from "fresh-session";
 
 export type State = {} & WithSession;
 
-const cookieSession = createCookieSession();
+const session = cookieSession();
 
-function session(req: Request, ctx: MiddlewareHandlerContext<State>) {
-  return cookieSession(req, ctx);
+function sessionHandler(req: Request, ctx: MiddlewareHandlerContext<State>) {
+  return session(req, ctx);
 }
-export const handler = [session];
+export const handler = [sessionHandler];
 ```
 
 Learn more about
@@ -107,20 +107,14 @@ export default function Dashboard({ data }: PageProps<Data>) {
 session value is cookie. can set the option for cookie.
 
 ```ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { createCookieSession, WithSession } from "fresh-session";
+import { cookieSession } from "fresh-session";
 
-export type State = {} & WithSession;
-
-const cookieSession = createCookieSession({
-  maxAge: 30, //Session keep is 30 seconds.
-  httpOnly: true,
-});
-
-export function session(req: Request, ctx: MiddlewareHandlerContext<State>) {
-  return cookieSession(req, ctx);
-}
-export const handler = [session];
+export const handler = [
+  cookieSession({
+    maxAge: 30, //Session keep is 30 seconds.
+    httpOnly: true,
+  }),
+];
 ```
 
 ## cookie session based on Redis
@@ -128,28 +122,24 @@ export const handler = [session];
 In addition to JWT, values can be stored in Redis.
 
 ```ts
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { createRedisSession, WithSession } from "fresh-session/mod.ts";
+import { redisSession } from "fresh-session/mod.ts";
 import { connect } from "redis/mod.ts";
-export type State = WithSession;
 
 const redis = await connect({
   hostname: "something redis server",
   port: 6379,
 });
 
-const redisSession = createRedisSession(redis);
+export const handler = [redisSession(redis)];
 
 // or Customizable cookie options and Redis key prefix
-const redisSession = createRedisSession(redis, {
-  keyPrefix: "S_",
-  maxAge: 10,
-});
 
-function session(req: Request, ctx: MiddlewareHandlerContext<State>) {
-  return redisSession(req, ctx);
-}
-export const handler = [session];
+export const handler = [
+  redisSession(redis, {
+    keyPrefix: "S_",
+    maxAge: 10,
+  }),
+];
 ```
 
 ## Credit

--- a/example/use_redis_store/import_map.json
+++ b/example/use_redis_store/import_map.json
@@ -7,6 +7,6 @@
     "@preact/signals": "https://esm.sh/*@preact/signals@1.0.3",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.0.1",
     "redis/": "https://deno.land/x/redis@v0.25.0/",
-    "fresh-session/": "https://deno.land/x/fresh-session@0.1.8/"
+    "fresh-session/": "https://deno.land/x/fresh-session@0.1.9/"
   }
 }

--- a/example/use_redis_store/routes/_middleware.ts
+++ b/example/use_redis_store/routes/_middleware.ts
@@ -1,5 +1,5 @@
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { createRedisSession, WithSession } from "fresh-session/mod.ts";
+import { redisSession, WithSession } from "fresh-session/mod.ts";
 import { connect } from "redis/mod.ts";
 export type State = WithSession;
 
@@ -8,15 +8,15 @@ const redis = await connect({
   port: 6379,
 });
 
-const redisSession = createRedisSession(redis, {
+const session = redisSession(redis, {
   maxAge: 10,
   httpOnly: true,
 });
 
-function session(req: Request, ctx: MiddlewareHandlerContext<State>) {
+function sessionHundler(req: Request, ctx: MiddlewareHandlerContext<State>) {
   if (req.url === `http://localhost:${ctx.localAddr?.port}/`) {
-    return redisSession(req, ctx);
+    return session(req, ctx);
   }
   return ctx.next();
 }
-export const handler = [session];
+export const handler = [sessionHundler];

--- a/example/use_redis_store/routes/_middleware.ts
+++ b/example/use_redis_store/routes/_middleware.ts
@@ -1,5 +1,5 @@
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { CreateRedisSession, WithSession } from "fresh-session/mod.ts";
+import { createRedisSession, WithSession } from "fresh-session/mod.ts";
 import { connect } from "redis/mod.ts";
 export type State = WithSession;
 
@@ -8,7 +8,10 @@ const redis = await connect({
   port: 6379,
 });
 
-const redisSession = CreateRedisSession(redis);
+const redisSession = createRedisSession(redis, {
+  maxAge: 10,
+  httpOnly: true,
+});
 
 function session(req: Request, ctx: MiddlewareHandlerContext<State>) {
   if (req.url === `http://localhost:${ctx.localAddr?.port}/`) {

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -2,6 +2,7 @@ export type { MiddlewareHandlerContext } from "https://deno.land/x/fresh@1.0.1/s
 export {
   getCookies,
   setCookie,
-  deleteCookie
+  deleteCookie,
+  type Cookie,
 } from "https://deno.land/std@0.150.0/http/mod.ts";
 export { create, decode, verify } from "https://deno.land/x/djwt@v2.7/mod.ts";

--- a/src/stores/cookie.ts
+++ b/src/stores/cookie.ts
@@ -6,6 +6,7 @@ import {
   setCookie,
   verify,
 } from "../deps.ts";
+import { type CookieOptions } from "./cookie_option.ts";
 import { Session } from "../session.ts";
 
 export function key() {
@@ -13,7 +14,7 @@ export function key() {
 
   if (!key) {
     console.warn(
-      "[FRESH SESSION] Warning: We didn't detect a env variable `APP_KEY`, if you are in production please fix this ASAP to avoid any security issue.",
+      "[FRESH SESSION] Warning: We didn't detect a env variable `APP_KEY`, if you are in production please fix this ASAP to avoid any security issue."
     );
   }
 
@@ -22,7 +23,7 @@ export function key() {
     new TextEncoder().encode(key || "not-secret"),
     { name: "HMAC", hash: "SHA-512" },
     false,
-    ["sign", "verify"],
+    ["sign", "verify"]
   );
 }
 
@@ -30,19 +31,26 @@ export type WithSession = {
   session: Session;
 };
 
-export function createCookieSessionStorage() {
-  return CookieSessionStorage.init();
+export function createCookieSessionStorage(cookieOptions?: CookieOptions) {
+  let cookieOptionsParam = cookieOptions;
+  if (!cookieOptionsParam) {
+    cookieOptionsParam = {};
+  }
+
+  return CookieSessionStorage.init(cookieOptionsParam);
 }
 
 export class CookieSessionStorage {
   #key: CryptoKey;
+  #cookieOptions: CookieOptions;
 
-  constructor(key: CryptoKey) {
+  constructor(key: CryptoKey, cookieOptions: CookieOptions) {
     this.#key = key;
+    this.#cookieOptions = cookieOptions;
   }
 
-  static async init() {
-    return new this(await key());
+  static async init(cookieOptions: CookieOptions) {
+    return new this(await key(), cookieOptions);
   }
 
   create() {
@@ -50,10 +58,12 @@ export class CookieSessionStorage {
   }
 
   exists(sessionId: string) {
-    return verify(sessionId, this.#key).then(() => true).catch((e) => {
-      console.warn("Invalid JWT token, creating new session...");
-      return false;
-    });
+    return verify(sessionId, this.#key)
+      .then(() => true)
+      .catch((e) => {
+        console.warn("Invalid JWT token, creating new session...");
+        return false;
+      });
   }
 
   get(sessionId: string) {
@@ -68,33 +78,36 @@ export class CookieSessionStorage {
       value: await create(
         { alg: "HS512", typ: "JWT" },
         { ...session.data, _flash: session.flashedData },
-        this.#key,
+        this.#key
       ),
       path: "/",
+      ...this.#cookieOptions,
     });
 
     return response;
   }
 }
 
-export async function cookieSession(
-  req: Request,
-  ctx: MiddlewareHandlerContext<WithSession>,
-) {
-  const { sessionId } = getCookies(req.headers);
-  const cookieSessionStorage = await createCookieSessionStorage();
-
-  if (
-    sessionId && (await cookieSessionStorage.exists(sessionId))
+export function CreateCookieSession(cookieOptions?: CookieOptions) {
+  return async function cookieSession(
+    req: Request,
+    ctx: MiddlewareHandlerContext<WithSession>
   ) {
-    ctx.state.session = await cookieSessionStorage.get(sessionId);
-  }
+    const { sessionId } = getCookies(req.headers);
+    const cookieSessionStorage = await createCookieSessionStorage(
+      cookieOptions
+    );
 
-  if (!ctx.state.session) {
-    ctx.state.session = cookieSessionStorage.create();
-  }
+    if (sessionId && (await cookieSessionStorage.exists(sessionId))) {
+      ctx.state.session = await cookieSessionStorage.get(sessionId);
+    }
 
-  const response = await ctx.next();
+    if (!ctx.state.session) {
+      ctx.state.session = cookieSessionStorage.create();
+    }
 
-  return cookieSessionStorage.persist(response, ctx.state.session);
+    const response = await ctx.next();
+
+    return cookieSessionStorage.persist(response, ctx.state.session);
+  };
 }

--- a/src/stores/cookie.ts
+++ b/src/stores/cookie.ts
@@ -88,7 +88,7 @@ export class CookieSessionStorage {
   }
 }
 
-export function CreateCookieSession(cookieOptions?: CookieOptions) {
+export function createCookieSession(cookieOptions?: CookieOptions) {
   return async function cookieSession(
     req: Request,
     ctx: MiddlewareHandlerContext<WithSession>

--- a/src/stores/cookie.ts
+++ b/src/stores/cookie.ts
@@ -88,8 +88,8 @@ export class CookieSessionStorage {
   }
 }
 
-export function createCookieSession(cookieOptions?: CookieOptions) {
-  return async function cookieSession(
+export function cookieSession(cookieOptions?: CookieOptions) {
+  return async function (
     req: Request,
     ctx: MiddlewareHandlerContext<WithSession>
   ) {

--- a/src/stores/cookie_option.ts
+++ b/src/stores/cookie_option.ts
@@ -1,3 +1,3 @@
 import { type Cookie } from "../deps.ts";
 
-export type CookieOptions = {};
+export type CookieOptions = Omit<Cookie, "name" | "value">;

--- a/src/stores/cookie_option.ts
+++ b/src/stores/cookie_option.ts
@@ -1,0 +1,3 @@
+import { type Cookie } from "../deps.ts";
+
+export type CookieOptions = {};

--- a/src/stores/cookie_option.ts
+++ b/src/stores/cookie_option.ts
@@ -1,3 +1,4 @@
 import { type Cookie } from "../deps.ts";
 
 export type CookieOptions = Omit<Cookie, "name" | "value">;
+export type CookieWithRedisOptions = CookieOptions & { keyPrefix?: string };

--- a/src/stores/redis.ts
+++ b/src/stores/redis.ts
@@ -86,9 +86,22 @@ export class RedisSessionStorage {
 
       deleteCookie(response.headers, "sessionId");
     } else {
+      let redisOptions: { ex?: number } = {};
+
+      if (this.#cookieOptions?.maxAge) {
+        redisOptions.ex = this.#cookieOptions.maxAge;
+      }
+      if (this.#cookieOptions?.expires) {
+        redisOptions.ex = Math.round(
+          ((this.#cookieOptions?.expires).getTime() - new Date().getTime()) /
+            1000
+        );
+      }
+
       await this.#store.set(
         this.key,
-        JSON.stringify({ data: session.data, _flash: session.flashedData })
+        JSON.stringify({ data: session.data, _flash: session.flashedData }),
+        redisOptions
       );
 
       setCookie(response.headers, {

--- a/src/stores/redis.ts
+++ b/src/stores/redis.ts
@@ -126,7 +126,7 @@ function hasKeyPrefix(
   return true;
 }
 
-export function createRedisSession(
+export function redisSession(
   store: Store,
   cookieWithRedisOptions?: CookieWithRedisOptions
 ) {
@@ -141,7 +141,7 @@ export function createRedisSession(
     setupCookieOptions = cookieOptions;
   }
 
-  return async function RedisSession(
+  return async function (
     req: Request,
     ctx: MiddlewareHandlerContext<WithSession>
   ) {

--- a/src/stores/redis.ts
+++ b/src/stores/redis.ts
@@ -4,6 +4,7 @@ import {
   MiddlewareHandlerContext,
   setCookie,
 } from "../deps.ts";
+import { type CookieOptions } from "./cookie_option.ts";
 import { Session } from "../session.ts";
 
 export type WithSession = {
@@ -19,24 +20,47 @@ export function createRedisSessionStorage(
   sessionId: string,
   store: Store,
   keyPrefix: string,
+  cookieOptions?: CookieOptions
 ) {
-  return RedisSessionStorage.init(sessionId, store, keyPrefix);
+  let cookieOptionsParam = cookieOptions;
+  if (!cookieOptionsParam) {
+    cookieOptionsParam = {};
+  }
+
+  return RedisSessionStorage.init(
+    sessionId,
+    store,
+    keyPrefix,
+    cookieOptionsParam
+  );
 }
 
 export class RedisSessionStorage {
   #sessionKey: string;
   #keyPrefix: string;
   #store: Store;
-  constructor(key: string, store: Store, keyPrefix: string) {
+  #cookieOptions: CookieOptions;
+  constructor(
+    key: string,
+    store: Store,
+    keyPrefix: string,
+    cookieOptions: CookieOptions
+  ) {
     this.#sessionKey = key;
     this.#store = store;
     this.#keyPrefix = keyPrefix;
+    this.#cookieOptions = cookieOptions;
   }
 
-  static init(sessionKey: string | undefined, store: Store, keyPrefix: string) {
+  static init(
+    sessionKey: string | undefined,
+    store: Store,
+    keyPrefix: string,
+    cookieOptions: CookieOptions
+  ) {
     let key = !sessionKey ? crypto.randomUUID() : sessionKey;
 
-    return new this(key, store, keyPrefix);
+    return new this(key, store, keyPrefix, cookieOptions);
   }
 
   get key() {
@@ -58,20 +82,20 @@ export class RedisSessionStorage {
 
   async persist(response: Response, session: Session) {
     if (session.doDelete) {
-      await this.#store.del(
-        this.key,
-      );
+      await this.#store.del(this.key);
 
       deleteCookie(response.headers, "sessionId");
     } else {
       await this.#store.set(
         this.key,
-        JSON.stringify({ data: session.data, _flash: session.flashedData }),
+        JSON.stringify({ data: session.data, _flash: session.flashedData })
       );
 
       setCookie(response.headers, {
         name: "sessionId",
         value: this.#sessionKey,
+        path: "/",
+        ...this.#cookieOptions,
       });
     }
 
@@ -79,23 +103,26 @@ export class RedisSessionStorage {
   }
 }
 
-export function CreateRedisSession(store: Store, keyPrefix = "session_") {
+export function CreateRedisSession(
+  store: Store,
+  keyPrefix = "session_",
+  cookieOptions?: CookieOptions
+) {
   const redisStore = store;
 
   return async function RedisSession(
     req: Request,
-    ctx: MiddlewareHandlerContext<WithSession>,
+    ctx: MiddlewareHandlerContext<WithSession>
   ) {
     const { sessionId } = getCookies(req.headers);
     const redisSessionStorage = await createRedisSessionStorage(
       sessionId,
       redisStore,
       keyPrefix,
+      cookieOptions
     );
 
-    if (
-      sessionId && (await redisSessionStorage.exists())
-    ) {
+    if (sessionId && (await redisSessionStorage.exists())) {
       ctx.state.session = await redisSessionStorage.get();
     }
 

--- a/tests/fixture/routes/_middleware.ts
+++ b/tests/fixture/routes/_middleware.ts
@@ -1,11 +1,10 @@
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { cookieSession, WithSession } from "fresh-session";
+import { CreateCookieSession, WithSession } from "fresh-session";
 
 export type State = {} & WithSession;
 
-export function handler(
-  req: Request,
-  ctx: MiddlewareHandlerContext<State>,
-) {
+const cookieSession = CreateCookieSession();
+
+export function handler(req: Request, ctx: MiddlewareHandlerContext<State>) {
   return cookieSession(req, ctx);
 }

--- a/tests/fixture/routes/_middleware.ts
+++ b/tests/fixture/routes/_middleware.ts
@@ -1,9 +1,9 @@
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { CreateCookieSession, WithSession } from "fresh-session";
+import { createCookieSession, WithSession } from "fresh-session";
 
 export type State = {} & WithSession;
 
-const cookieSession = CreateCookieSession();
+const cookieSession = createCookieSession();
 
 export function handler(req: Request, ctx: MiddlewareHandlerContext<State>) {
   return cookieSession(req, ctx);

--- a/tests/fixture/routes/_middleware.ts
+++ b/tests/fixture/routes/_middleware.ts
@@ -1,10 +1,3 @@
-import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { createCookieSession, WithSession } from "fresh-session";
+import { cookieSession } from "fresh-session";
 
-export type State = {} & WithSession;
-
-const cookieSession = createCookieSession();
-
-export function handler(req: Request, ctx: MiddlewareHandlerContext<State>) {
-  return cookieSession(req, ctx);
-}
+export const handler = cookieSession();


### PR DESCRIPTION

Hello, @xstevenyung.

Both cookie sessions and redis sessions use cookies, but I was unable to set cookie options, so I added a feature.
Specifically, I wanted to set max-age, http-only, etc.

For example.

```ts
/// _middleware.ts
import { MiddlewareHandlerContext } from "$fresh/server.ts";
import { CreateCookieSession, WithSession } from "fresh-session";

export type State = {} & WithSession;

const cookieSession = CreateCookieSession({maxAge: 30, httpOnly: true});

export function handler(req: Request, ctx: MiddlewareHandlerContext<State>) {
  return cookieSession(req, ctx);
}

```

```ts
/// _middleware.ts
import { MiddlewareHandlerContext } from "$fresh/server.ts";
import { CreateRedisSession, WithSession } from "fresh-session/mod.ts";
import { connect } from "redis/mod.ts";
export type State = WithSession;

const redis = await connect({
  hostname: "redis",
  port: 6379,
});

const redisSession = CreateRedisSession(redis, "session_", { maxAge: 10 });

function session(req: Request, ctx: MiddlewareHandlerContext<State>) {
  if (req.url === `http://localhost:${ctx.localAddr?.port}/`) {
    return redisSession(req, ctx);
  }
  return ctx.next();
}
export const handler = [session];

```