### PR TITLE
encrypt cookie storage with iron-webcrypto

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -20,7 +20,7 @@ jobs:
       DENO_ENV: testing
       BASE_URL: http://localhost:8000
       DENO_DIR: deno_dir
-      APP_KEY: not-secret-at-all
+      APP_KEY: password-at-least-32-characters-long
     steps:
       - name: Setup repo
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ import {
 
 ### Setup secret key
 
-Fresh Session currently uses [JSON Web Token](https://jwt.io/) under the hood to
-create and manage session in the cookies.
+Fresh Session currently uses
+[iron-webcrypto](https://github.com/brc-dd/iron-webcrypto) encrypted cookie
+contents.
 
-JWT requires a secret key to sign new tokens. Fresh Session uses the secret key
-from your [environment variable](https://deno.land/std/dotenv/load.ts)
-`APP_KEY`.
+iron-webcrypto requires a secret key to encrypt the session payload. Fresh
+Session uses the secret key from your
+[environment variable](https://deno.land/std/dotenv/load.ts) `APP_KEY`.
 
 If you don't know how to setup environment variable locally, I wrote
 [an article about .env file in Deno Fresh](https://xstevenyung.com/blog/read-.env-file-in-deno-fresh).
@@ -124,7 +125,7 @@ export const handler = [
 
 ## cookie session based on Redis
 
-In addition to JWT, values can be stored in Redis.
+In addition to storing session data in cookies, values can be stored in Redis.
 
 ```ts
 import { redisSession } from "fresh-session/mod.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,8 +1,10 @@
-export type { Plugin, MiddlewareHandlerContext, MiddlewareHandler} from "https://deno.land/x/fresh@1.5.4/server.ts";
+import { IndexBuilderOn } from "drizzle-orm/sqlite-core";
+
+export type { Plugin, MiddlewareHandlerContext, MiddlewareHandler } from "https://deno.land/x/fresh@1.5.4/server.ts";
 export {
   type Cookie,
   deleteCookie,
   getCookies,
   setCookie,
 } from "https://deno.land/std@0.207.0/http/mod.ts";
-export { create, decode, verify } from "https://deno.land/x/djwt@v3.0.1/mod.ts";
+export { seal, unseal, defaults as ironDefaults } from 'https://deno.land/x/iron@v1.0.0/mod.ts'

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,10 +1,18 @@
 import { IndexBuilderOn } from "drizzle-orm/sqlite-core";
 
-export type { Plugin, MiddlewareHandlerContext, MiddlewareHandler } from "https://deno.land/x/fresh@1.5.4/server.ts";
+export type {
+  MiddlewareHandler,
+  MiddlewareHandlerContext,
+  Plugin,
+} from "https://deno.land/x/fresh@1.5.4/server.ts";
 export {
   type Cookie,
   deleteCookie,
   getCookies,
   setCookie,
 } from "https://deno.land/std@0.207.0/http/mod.ts";
-export { seal, unseal, defaults as ironDefaults } from 'https://deno.land/x/iron@v1.0.0/mod.ts'
+export {
+  defaults as ironDefaults,
+  seal,
+  unseal,
+} from "https://deno.land/x/iron@v1.0.0/mod.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,3 @@
-import { IndexBuilderOn } from "drizzle-orm/sqlite-core";
-
 export type {
   MiddlewareHandler,
   MiddlewareHandlerContext,

--- a/src/plugins/cookie_session_plugin.ts
+++ b/src/plugins/cookie_session_plugin.ts
@@ -1,13 +1,16 @@
 import type {
-  Plugin,
-  MiddlewareHandlerContext,
   MiddlewareHandler,
+  MiddlewareHandlerContext,
+  Plugin,
 } from "../deps.ts";
 import { cookieSession } from "../stores/cookie.ts";
 import { CookieOptions } from "../stores/cookie_option.ts";
 import { sessionModule } from "../stores/interface.ts";
 
-export function getCookieSessionHandler(session: sessionModule, excludePath: string[]): MiddlewareHandler {
+export function getCookieSessionHandler(
+  session: sessionModule,
+  excludePath: string[],
+): MiddlewareHandler {
   return function (req: Request, ctx: MiddlewareHandlerContext) {
     if (excludePath.includes(new URL(req.url).pathname)) {
       return ctx.next();
@@ -16,7 +19,11 @@ export function getCookieSessionHandler(session: sessionModule, excludePath: str
   };
 }
 
-export function getCookieSessionPlugin(path = "/", excludePath = [],  cookieOptions?: CookieOptions): Plugin {
+export function getCookieSessionPlugin(
+  path = "/",
+  excludePath = [],
+  cookieOptions?: CookieOptions,
+): Plugin {
   const session = cookieSession(cookieOptions);
   const handler = getCookieSessionHandler(session, excludePath);
 

--- a/src/plugins/kv_session_plugin.ts
+++ b/src/plugins/kv_session_plugin.ts
@@ -1,13 +1,16 @@
 import type {
-  Plugin,
-  MiddlewareHandlerContext,
   MiddlewareHandler,
+  MiddlewareHandlerContext,
+  Plugin,
 } from "../deps.ts";
 import { kvSession } from "../stores/kv.ts";
 import { CookieOptions } from "../stores/cookie_option.ts";
 import { sessionModule } from "../stores/interface.ts";
 
-export function getKvSessionHandler(session: sessionModule, excludePath: string[]): MiddlewareHandler {
+export function getKvSessionHandler(
+  session: sessionModule,
+  excludePath: string[],
+): MiddlewareHandler {
   return function (req: Request, ctx: MiddlewareHandlerContext) {
     if (excludePath.includes(new URL(req.url).pathname)) {
       return ctx.next();
@@ -16,7 +19,12 @@ export function getKvSessionHandler(session: sessionModule, excludePath: string[
   };
 }
 
-export function getKvSessionPlugin(storePath: string|null, path = "/", excludePath = [], cookieOptions?: CookieOptions): Plugin {
+export function getKvSessionPlugin(
+  storePath: string | null,
+  path = "/",
+  excludePath = [],
+  cookieOptions?: CookieOptions,
+): Plugin {
   const session = kvSession(storePath, cookieOptions);
   const handler = getKvSessionHandler(session, excludePath);
 

--- a/src/plugins/redis_session_plugin.ts
+++ b/src/plugins/redis_session_plugin.ts
@@ -1,13 +1,16 @@
 import type {
-  Plugin,
-  MiddlewareHandlerContext,
   MiddlewareHandler,
+  MiddlewareHandlerContext,
+  Plugin,
 } from "../deps.ts";
-import { Store, redisSession } from "../stores/redis.ts";
+import { redisSession, Store } from "../stores/redis.ts";
 import { CookieOptions } from "../stores/cookie_option.ts";
 import { sessionModule } from "../stores/interface.ts";
 
-export function getRedisSessionHandler(session: sessionModule, excludePath: string[]): MiddlewareHandler {
+export function getRedisSessionHandler(
+  session: sessionModule,
+  excludePath: string[],
+): MiddlewareHandler {
   return function (req: Request, ctx: MiddlewareHandlerContext) {
     if (excludePath.includes(new URL(req.url).pathname)) {
       return ctx.next();
@@ -16,7 +19,12 @@ export function getRedisSessionHandler(session: sessionModule, excludePath: stri
   };
 }
 
-export function getRedisSessionPlugin(store: Store, path = "/", excludePath = [],  cookieOptions?: CookieOptions): Plugin {
+export function getRedisSessionPlugin(
+  store: Store,
+  path = "/",
+  excludePath = [],
+  cookieOptions?: CookieOptions,
+): Plugin {
   const session = redisSession(store, cookieOptions);
   const handler = getRedisSessionHandler(session, excludePath);
 

--- a/src/stores/cookie.ts
+++ b/src/stores/cookie.ts
@@ -1,10 +1,10 @@
 import {
   getCookies,
-  MiddlewareHandlerContext,
-  setCookie,
-  seal,
-  unseal,
   ironDefaults,
+  MiddlewareHandlerContext,
+  seal,
+  setCookie,
+  unseal,
 } from "../deps.ts";
 import { type CookieOptions } from "./cookie_option.ts";
 import { Session } from "../session.ts";
@@ -35,7 +35,12 @@ export class CookieSessionStorage {
   }
 
   exists(sessionId: string) {
-    return unseal(globalThis.crypto, sessionId, Deno.env.get('APP_KEY') as string, ironDefaults)
+    return unseal(
+      globalThis.crypto,
+      sessionId,
+      Deno.env.get("APP_KEY") as string,
+      ironDefaults,
+    )
       .then(() => true)
       .catch((e) => {
         console.warn("Invalid session, creating new session...");
@@ -44,7 +49,12 @@ export class CookieSessionStorage {
   }
 
   async get(sessionId: string) {
-    const decryptedData = await unseal(globalThis.crypto, sessionId, Deno.env.get('APP_KEY') as string, ironDefaults)
+    const decryptedData = await unseal(
+      globalThis.crypto,
+      sessionId,
+      Deno.env.get("APP_KEY") as string,
+      ironDefaults,
+    );
 
     const { _flash = {}, ...data } = decryptedData;
     return new Session(data as object, _flash);
@@ -55,7 +65,12 @@ export class CookieSessionStorage {
       this.keyRotate();
     }
 
-    const encryptedData = await seal(globalThis.crypto, { ...session.data, _flash: session.flashedData }, Deno.env.get('APP_KEY') as string, ironDefaults)
+    const encryptedData = await seal(
+      globalThis.crypto,
+      { ...session.data, _flash: session.flashedData },
+      Deno.env.get("APP_KEY") as string,
+      ironDefaults,
+    );
 
     setCookie(response.headers, {
       name: "sessionId",

--- a/src/stores/cookie.ts
+++ b/src/stores/cookie.ts
@@ -1,32 +1,14 @@
 import {
-  create,
-  decode,
   getCookies,
   MiddlewareHandlerContext,
   setCookie,
-  verify,
+  seal,
+  unseal,
+  ironDefaults,
 } from "../deps.ts";
 import { type CookieOptions } from "./cookie_option.ts";
 import { Session } from "../session.ts";
 import type { WithSession } from "./interface.ts";
-
-export function key() {
-  const key = Deno.env.get("APP_KEY");
-
-  if (!key) {
-    console.warn(
-      "[FRESH SESSION] Warning: We didn't detect a env variable `APP_KEY`, if you are in production please fix this ASAP to avoid any security issue.",
-    );
-  }
-
-  return crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(key || "not-secret"),
-    { name: "HMAC", hash: "SHA-512" },
-    false,
-    ["sign", "verify"],
-  );
-}
 
 export function createCookieSessionStorage(cookieOptions?: CookieOptions) {
   let cookieOptionsParam = cookieOptions;
@@ -38,16 +20,14 @@ export function createCookieSessionStorage(cookieOptions?: CookieOptions) {
 }
 
 export class CookieSessionStorage {
-  #key: CryptoKey;
   #cookieOptions: CookieOptions;
 
-  constructor(key: CryptoKey, cookieOptions: CookieOptions) {
-    this.#key = key;
+  constructor(cookieOptions: CookieOptions) {
     this.#cookieOptions = cookieOptions;
   }
 
-  static async init(cookieOptions: CookieOptions) {
-    return new this(await key(), cookieOptions);
+  static init(cookieOptions: CookieOptions) {
+    return new this(cookieOptions);
   }
 
   create() {
@@ -55,17 +35,18 @@ export class CookieSessionStorage {
   }
 
   exists(sessionId: string) {
-    return verify(sessionId, this.#key)
+    return unseal(globalThis.crypto, sessionId, Deno.env.get('APP_KEY') as string, ironDefaults)
       .then(() => true)
       .catch((e) => {
-        console.warn("Invalid JWT token, creating new session...");
+        console.warn("Invalid session, creating new session...");
         return false;
       });
   }
 
-  get(sessionId: string) {
-    const [, payload] = decode(sessionId);
-    const { _flash = {}, ...data } = payload;
+  async get(sessionId: string) {
+    const decryptedData = await unseal(globalThis.crypto, sessionId, Deno.env.get('APP_KEY') as string, ironDefaults)
+
+    const { _flash = {}, ...data } = decryptedData;
     return new Session(data as object, _flash);
   }
 
@@ -74,13 +55,11 @@ export class CookieSessionStorage {
       this.keyRotate();
     }
 
+    const encryptedData = await seal(globalThis.crypto, { ...session.data, _flash: session.flashedData }, Deno.env.get('APP_KEY') as string, ironDefaults)
+
     setCookie(response.headers, {
       name: "sessionId",
-      value: await create(
-        { alg: "HS512", typ: "JWT" },
-        { ...session.data, _flash: session.flashedData },
-        this.#key,
-      ),
+      value: encryptedData,
       path: "/",
       ...this.#cookieOptions,
     });

--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -4,4 +4,7 @@ export type WithSession = {
   session: Session;
 };
 
-export type sessionModule =(req: Request, ctx: MiddlewareHandlerContext) => Promise<Response>
+export type sessionModule = (
+  req: Request,
+  ctx: MiddlewareHandlerContext,
+) => Promise<Response>;

--- a/src/stores/kv.ts
+++ b/src/stores/kv.ts
@@ -129,7 +129,7 @@ function hasKeyPrefix(
 }
 
 export function kvSession(
-  storePath: string|null,
+  storePath: string | null,
   cookieWithRedisOptions?: CookieWithRedisOptions,
 ) {
   let setupKeyPrefix = "session_";

--- a/tests/fixture/dev.ts
+++ b/tests/fixture/dev.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run -A --watch=static/,routes/
 
-Deno.env.set("APP_KEY", "not-secret");
+Deno.env.set("APP_KEY", "password-at-least-32-characters-long");
 
 import dev from "$fresh/dev.ts";
 

--- a/tests/wrapper.js
+++ b/tests/wrapper.js
@@ -1,7 +1,7 @@
 import { delay } from "$std/async/delay.ts";
 import { startFreshServer } from "$fresh/tests/test_utils.ts";
 
-Deno.env.set("APP_KEY", "something_for_testing");
+Deno.env.set("APP_KEY", "password-at-least-32-characters-long");
 
 export const BASE_URL = "http://localhost:8000";
 


### PR DESCRIPTION
Right now, cookies are signed with JWT, which is good for preventing tampering with the cookie, but the contents of the cookie are still readable by the client since they're not encrypted.

This is a potential security problem, I don't believe we should allow anyone to inspect the contents of potentially sensitive info users want to put in a cookie.

[iron-webcrypto](https://github.com/brc-dd/iron-webcrypto) is a good solution here IMO because it's easy to configure (just need a long password string, and we already use APP_KEY so many users may not have to reconfigure anything) and it solves both signing _and_ encryption at the same time. Users may have to increase the length of their APP_KEY because iron-webcrypto requires a key length minimum of 32 characters (which we can lower or remove, but iron-webcrypto default is 32 characters so I recommending sticking with it)

If this is too drastic of a change or opinions are strong on using JWT, I understand, but we should put security disclaimers if we're not encrypting CookieStorage cookies. This change doesn't impact the Redis or KV drivers.